### PR TITLE
Config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ SLAMon_push | `new org.slamon.SLAMonJupsHandler(JBOSS_UNIFIED_PUSH_SERVER_URL, A
 SLAMon      | `new org.slamon.SLAMonWorkItemHandler(AGENT_FLEET_MANAGER_URL)`  generic SLAMon task with task type and version specified in the process
 SLAMon_task | `new org.slamon.SLAMonWorkItemHandler(AGENT_FLEET_MANAGER_URL, TASK_HANDLER_NAME, TASK_HANDLER_VERSION)` handler with task type and version already bound for convenience
 
+It's also possible to define AFM Url as a java system property named `slamon.afm.url`. In this case the AFM Url can be
+omitted in the work item handler definition by using the two parameter constructor instead, e.g.
+`new org.slamon.SLAMonWorkItemHandler("my_handler", 3)`.
+
+The default interval for pollings task results from AFM is 15 seconds. This may be altered by setting `slamon.afm.polling`
+system property. The value is set to amount of seconds between polling requests.
+
 ###### Parameters for SLAMonJupsHandler:
 
 Parameter      | Description

--- a/src/main/java/org/slamon/Afm.java
+++ b/src/main/java/org/slamon/Afm.java
@@ -61,6 +61,7 @@ public class Afm {
     }
 
     private Afm(String url) {
+        log.log(Level.INFO, "Creating a new AFM client instance for {0}", url);
         mUrl = url;
     }
 

--- a/src/main/java/org/slamon/Afm.java
+++ b/src/main/java/org/slamon/Afm.java
@@ -31,6 +31,7 @@ public class Afm {
 
     static final HashMap<String, Afm> sAfmServers = new HashMap<String, Afm>();
     static final JsonFactory sJsonFactory = new GsonFactory();
+    static long sPollInterval = Long.parseLong(System.getProperty("slamon.afm.polling", "15"));
 
     final ScheduledExecutorService mExecutor = Executors.newSingleThreadScheduledExecutor();
     final HashMap<String, ResultCallback> mTasks = new HashMap<String, ResultCallback>();
@@ -42,6 +43,10 @@ public class Afm {
         public void initialize(HttpRequest request) throws IOException {
             request.setParser(new JsonObjectParser(sJsonFactory));
         }
+    }
+
+    public static void setPollInterval(long pollInterval) {
+        sPollInterval = pollInterval;
     }
 
     /**
@@ -228,7 +233,7 @@ public class Afm {
                             getTask(responseUrl, task);
                         }
                     }
-                }, 1000, TimeUnit.MILLISECONDS);
+                }, sPollInterval, TimeUnit.SECONDS);
             }
         }
     }

--- a/src/main/java/org/slamon/SLAMonWorkItemHandler.java
+++ b/src/main/java/org/slamon/SLAMonWorkItemHandler.java
@@ -27,16 +27,36 @@ public class SLAMonWorkItemHandler implements WorkItemHandler {
     /**
      * Construct SLAMonWorkItemHandler with specific AFM URL.
      */
-    public SLAMonWorkItemHandler(String url) {
+    public SLAMonWorkItemHandler(String url) throws Exception {
         mUrl = url;
+        if (mUrl == null) {
+            throw new Exception("No AFM URL provided for SLAMonWorkItemHandler");
+        }
+    }
+
+    /**
+     * Construct SLAMonWorkItemHandler with system AFM URL.
+     */
+    public SLAMonWorkItemHandler() throws Exception {
+        this(System.getProperty("slamon.afm.url"));
     }
 
     /**
      * Convenience overload to predefine task type and
      * task version so that these can be omitted in work item parameters.
      */
-    public SLAMonWorkItemHandler(String url, String taskType, int taskVersion) {
-        mUrl = url;
+    public SLAMonWorkItemHandler(String taskType, int taskVersion) throws Exception {
+        this();
+        mTaskType = taskType;
+        mTaskVersion = taskVersion;
+    }
+
+    /**
+     * Convenience overload to predefine task type and
+     * task version so that these can be omitted in work item parameters.
+     */
+    public SLAMonWorkItemHandler(String url, String taskType, int taskVersion) throws Exception {
+        this(url);
         mTaskType = taskType;
         mTaskVersion = taskVersion;
     }

--- a/src/test/java/org/slamon/AfmTest.java
+++ b/src/test/java/org/slamon/AfmTest.java
@@ -122,6 +122,16 @@ public class AfmTest {
     }
 
     @Test
+    public void testSharedInstance() throws InterruptedException, ExecutionException, TimeoutException {
+        Afm afm1 = Afm.get(HttpTesting.SIMPLE_URL);
+        Afm afm2 = Afm.get(HttpTesting.SIMPLE_URL);
+        Afm afm3 = Afm.get(HttpTesting.SIMPLE_URL+"test/");
+
+        assertSame(afm1,afm2);
+        assertNotSame(afm2, afm3);
+    }
+
+    @Test
     public void testSuccessResult() throws InterruptedException, ExecutionException, TimeoutException {
 
         Afm afm = Afm.get(HttpTesting.SIMPLE_URL);

--- a/src/test/java/org/slamon/AfmTest.java
+++ b/src/test/java/org/slamon/AfmTest.java
@@ -118,6 +118,7 @@ public class AfmTest {
     @Before
     public void ressetAfm() {
         Afm.resetAll();
+        Afm.setPollInterval(1);
     }
 
     @Test


### PR DESCRIPTION
Added two properties configurable via java system properties:
- default AFM URL (previously definable only per task handler basis)
- task result polling interval (previously hard coded)
