### PR TITLE
StatsD integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,8 @@ This can be overridden with _category_ definition in the work item definitions.
 #### SLAMonWorkItemHandler
 
 Each SLAMon task type is represented by a separate custom work item in jBPM.
-
 The DataInput of each custom work item corresponds to the input data parameter of the equivalent SLAMon task handler.
-
 Likewise, the DataOutput of each custom work item corresponds to the response data return by the equivalent SLAMon task handler.
-
 Please refer the readme files of the SLAMon Agent and the corresponding task types that you are going to use for more details.
 
 
@@ -223,14 +220,44 @@ SLAMon Push Notification accepts the following DataInput:
   * sound - the sound that will be played on the receiving devices
 
 Take note that a copy of the notification will always be sent to the variant id defined in the Work Item Handler registration. For example, this can be the variant ID used by the service operation center.
-
 A notification can also be sent to all devices. To do this, use "all" instead of specifying a specific variant_id.
-
 If you do not have a specific sound to play, please use "default".
 
 SLAMon Push Notification returns the following DataOutput:
 
   * result - either "successful" or "failed"
+
+### Publishing statistics to StatsD with StatsdProcessEventListener
+
+The slamon-jbpm package includes an *ProcessEventListener* implementation to send statistics of
+started, completed and aborted processes to a StatsD server.
+
+StatsdProcessEventListener will record
+
+  * gauge values for number of running projects, for both total and per process definition (slamon.bpms.<process>.running)
+  * counters for started processes per process definition (slamon.bpms.<process>.started)
+  * timers for completed and aborted processes per process definition  (slamon.bpms.<process>.completed and  slamon.bpms.<process>.aborted)
+
+Enable StatsD stats reporting by adding an entry in the project deployment descriptor with
+value = `new org.slamon.StatsdProcessEventListener()` and resolver type = mvel.
+
+#### Configuration
+
+StatsdProcessEventListener may be configured in two ways: constructor parameters and system properties.
+
+Constructors:
+
+```java
+public StatsdProcessEventListener(String prefix, String host, int port) throws Exception
+public StatsdProcessEventListener(String host, int port) throws Exception
+public StatsdProcessEventListener()
+```
+
+Property             | Default     | Description
+-------------------- | ----------- | -------------------
+slamon.statsd.prefix | slamon.bpms | Prefix for StatsD values
+slamon.statsd.host   |             | Hostname of the StatsD server
+slamon.statsd.port   | 8125        | Port of the StatsD server
 
 
 Docker images

--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,10 @@ dependencies {
     compile 'org.drools:drools-compiler:6.2.0.Final'
     compile 'com.google.http-client:google-http-client:1.19.0'
     compile 'com.google.http-client:google-http-client-gson:1.19.0'
+    compile 'com.timgroup:java-statsd-client:3.1.0'
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-core:1.3'
+    testCompile 'org.mockito:mockito-core:1.10.19'
 }
 
 task getDepsCompile(type: Copy) {

--- a/src/main/java/org/slamon/SLAMonJupsHandler.java
+++ b/src/main/java/org/slamon/SLAMonJupsHandler.java
@@ -51,14 +51,8 @@ public class SLAMonJupsHandler implements WorkItemHandler {
 
         final String deploymentId = ((WorkItemImpl) workItem).getDeploymentId();
 
-        EngineHolder engine = null;
-        try {
-            engine = new EngineHolder(deploymentId);
+        try (EngineHolder engine = new EngineHolder(deploymentId)) {
             testId = Util.processId(engine.getEngine(), workItem);
-        } finally {
-            if (engine != null) {
-                engine.close();
-            }
         }
 
         PushNotification notification;

--- a/src/main/java/org/slamon/SLAMonWorkItemHandler.java
+++ b/src/main/java/org/slamon/SLAMonWorkItemHandler.java
@@ -145,11 +145,11 @@ public class SLAMonWorkItemHandler implements WorkItemHandler {
                     mItemIdMap.remove(localWorkItemId);
                 }
 
-                Map<String, Object> results = new HashMap<String, Object>();
-                results.put("task_error", task.task_error);
+                log.log(Level.SEVERE, "A task returned as failed, aborting task {0}. Error: {1}", new Object[]{
+                        task.task_id, task.task_error});
 
                 try (EngineHolder engine = new EngineHolder(deploymentId)) {
-                    engine.getEngine().getKieSession().getWorkItemManager().completeWorkItem(workItem.getId(), results);
+                    engine.getEngine().getKieSession().getWorkItemManager().abortWorkItem(workItem.getId());
                 }
             }
         });

--- a/src/main/java/org/slamon/SLAMonWorkItemHandler.java
+++ b/src/main/java/org/slamon/SLAMonWorkItemHandler.java
@@ -83,18 +83,12 @@ public class SLAMonWorkItemHandler implements WorkItemHandler {
 
         final String deploymentId = ((WorkItemImpl) workItem).getDeploymentId();
 
-        EngineHolder engine = null;
-        try {
-            engine = new EngineHolder(deploymentId);
+        try (EngineHolder engine = new EngineHolder(deploymentId)) {
             task = new Task(
                     Util.itemId(engine.getEngine(), workItem),
                     Util.processId(engine.getEngine(), workItem),
                     taskType,
                     taskVersion);
-        } finally {
-            if (engine != null) {
-                engine.close();
-            }
         }
 
         task.task_data = new HashMap<String, Object>();
@@ -124,9 +118,7 @@ public class SLAMonWorkItemHandler implements WorkItemHandler {
                     mItemIdMap.remove(localWorkItemId);
                 }
 
-                //try (EngineHolder engine = new EngineHolder(deploymentId)) {
-                EngineHolder engine = null;
-                try {
+                try (EngineHolder engine = new EngineHolder(deploymentId)) {
 
                     HashMap<String, Object> results = new HashMap<String, Object>();
                     for (Map.Entry<String, Object> e : task.task_result.entrySet()) {
@@ -142,12 +134,7 @@ public class SLAMonWorkItemHandler implements WorkItemHandler {
                             log.log(Level.SEVERE, "Error during output variable conversions: {0}", e2.getMessage());
                         }
                     }
-                    engine = new EngineHolder(deploymentId);
                     engine.getEngine().getKieSession().getWorkItemManager().completeWorkItem(workItem.getId(), results);
-                } finally {
-                    if (engine != null) {
-                        engine.close();
-                    }
                 }
             }
 
@@ -161,15 +148,8 @@ public class SLAMonWorkItemHandler implements WorkItemHandler {
                 Map<String, Object> results = new HashMap<String, Object>();
                 results.put("task_error", task.task_error);
 
-                //try (EngineHolder engine = new EngineHolder(deploymentId)) {
-                EngineHolder engine = null;
-                try {
-                    engine = new EngineHolder(deploymentId);
+                try (EngineHolder engine = new EngineHolder(deploymentId)) {
                     engine.getEngine().getKieSession().getWorkItemManager().completeWorkItem(workItem.getId(), results);
-                } finally {
-                    if (engine != null) {
-                        engine.close();
-                    }
                 }
             }
         });

--- a/src/main/java/org/slamon/StatsdProcessEventListener.java
+++ b/src/main/java/org/slamon/StatsdProcessEventListener.java
@@ -1,0 +1,203 @@
+package org.slamon;
+
+import org.kie.api.event.process.*;
+import com.timgroup.statsd.StatsDClient;
+import com.timgroup.statsd.NonBlockingStatsDClient;
+import org.kie.api.runtime.KieRuntime;
+import org.kie.api.runtime.process.ProcessInstance;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class StatsdProcessEventListener implements ProcessEventListener {
+
+    static final Logger log = Logger.getLogger(StatsdProcessEventListener.class.getCanonicalName());
+
+    private final StatsDClient mClient;
+    private StringBuilder mBuilder = new StringBuilder(32);
+    private final Map<Long, Long> mRunningProcesses = new HashMap<>();
+    private final ProcessCounterMap mTotalProcesses = new ProcessCounterMap();
+
+    private class ProcessCounter {
+        private long mValue;
+
+        ProcessCounter(long initialValue) {
+            mValue = initialValue;
+        }
+
+        long inc() {
+            return ++mValue;
+        }
+
+        long dec() {
+            return --mValue;
+        }
+
+        long get() {
+            return mValue;
+        }
+    }
+
+    private class ProcessCounterMap extends HashMap<String, ProcessCounter> {
+        long inc(String processName) {
+            ProcessCounter counter = get(processName);
+            if (counter == null) {
+                put(processName, new ProcessCounter(1));
+                return 1;
+            } else {
+                return counter.inc();
+            }
+        }
+
+        long inc(ProcessEvent event) {
+            return inc(event.getProcessInstance().getProcessId());
+        }
+
+        long dec(String processName) {
+            ProcessCounter counter = get(processName);
+            if (counter == null) {
+                put(processName, new ProcessCounter(-1));
+                return -1;
+            } else {
+                return counter.dec();
+            }
+        }
+
+        long dec(ProcessEvent event) {
+            return dec(event.getProcessInstance().getProcessId());
+        }
+    }
+
+    StatsdProcessEventListener(StatsDClient client) {
+        mClient = client;
+    }
+
+    public StatsdProcessEventListener(String prefix, String host, int port) throws Exception {
+        log.log(Level.INFO, "Loaded StatsD ProcessEventListener ({0},{1},{2})",
+                new Object[]{prefix, host, Integer.toString(port)});
+        if (prefix == null) {
+            throw new java.lang.Exception("No StatsD prefix defined");
+        } else if (host == null) {
+            throw new java.lang.Exception("No StatsD host defined");
+        } else if (port == 0) {
+            throw new java.lang.Exception("Invalid StatsD port defined");
+        }
+        mClient = new NonBlockingStatsDClient(prefix, host, port);
+    }
+
+    public StatsdProcessEventListener(String host, int port) throws Exception {
+        this(System.getProperty("slamon.statsd.prefix", "slamon.bpms"), host, port);
+    }
+
+    public StatsdProcessEventListener() throws Exception {
+        this(System.getProperty("slamon.statsd.host"),
+                Integer.parseInt(System.getProperty("slamon.statsd.port", "8125")));
+    }
+
+    static private String filterName(String name) {
+        return name.replaceAll("[^a-zA-Z0-9]", "");
+    }
+
+    static private String createProcessName(ProcessInstance process, KieRuntime runtime) {
+        long parentId = process.getParentProcessInstanceId();
+        if (parentId != 0) {
+            return createProcessName(runtime.getProcessInstance(parentId), runtime) + '.' + filterName(process.getProcessName());
+        }
+        return filterName(process.getProcessName());
+    }
+
+    private String createMetricName(ProcessEvent event, String suffix) {
+        synchronized (mClient) {
+            mBuilder.setLength(0);
+            mBuilder.append("process.")
+                    .append(createProcessName(event.getProcessInstance(), event.getKieRuntime()))
+                    .append('.')
+                    .append(suffix);
+            return mBuilder.toString();
+        }
+    }
+
+    @Override
+    public void beforeProcessStarted(ProcessStartedEvent event) {
+
+    }
+
+    @Override
+    public void afterProcessStarted(ProcessStartedEvent event) {
+        log.log(Level.FINE, "Process {0} started at {1}", new Object[]{event.getProcessInstance().getId(), System.currentTimeMillis()});
+        synchronized (mClient) {
+            // Store process start time to calculate duration
+            mRunningProcesses.put(event.getProcessInstance().getId(), System.currentTimeMillis());
+
+            // send stats
+            mClient.recordGaugeValue("process.running", mRunningProcesses.size());
+            mClient.recordGaugeValue(createMetricName(event, "running"), mTotalProcesses.inc(event));
+            mClient.incrementCounter(createMetricName(event, "started"));
+        }
+    }
+
+    @Override
+    public void beforeProcessCompleted(ProcessCompletedEvent event) {
+
+    }
+
+    @Override
+    public void afterProcessCompleted(ProcessCompletedEvent event) {
+        synchronized (mClient) {
+            // calculate process duration from stored value
+            long processStartTime = mRunningProcesses.remove(event.getProcessInstance().getId());
+
+            // Generate metric name for recording stats
+            String metricName;
+            switch (event.getProcessInstance().getState()) {
+                case ProcessInstance.STATE_COMPLETED:
+                    metricName = createMetricName(event, "completed");
+                    break;
+                case ProcessInstance.STATE_ABORTED:
+                    metricName = createMetricName(event, "aborted");
+                    break;
+                default:
+                    log.log(Level.WARNING, "Process {0} completed with unexpected state: {1}", new Object[]{
+                            event.getProcessInstance().getId(), event.getProcessInstance().getState()});
+                    return;
+            }
+
+            log.log(Level.FINE, "Recording stats for process {0} with key {1}", new Object[]{
+                    event.getProcessInstance().getId(), metricName});
+
+            // send stats
+            mClient.recordGaugeValue("process.running", mRunningProcesses.size());
+            mClient.recordGaugeValue(createMetricName(event, "running"), mTotalProcesses.dec(event));
+            mClient.incrementCounter(metricName);
+            mClient.recordExecutionTimeToNow(metricName, processStartTime);
+        }
+    }
+
+    @Override
+    public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {
+    }
+
+    @Override
+    public void afterNodeTriggered(ProcessNodeTriggeredEvent event) {
+
+    }
+
+    @Override
+    public void beforeNodeLeft(ProcessNodeLeftEvent event) {
+    }
+
+    @Override
+    public void afterNodeLeft(ProcessNodeLeftEvent event) {
+    }
+
+    @Override
+    public void beforeVariableChanged(ProcessVariableChangedEvent event) {
+    }
+
+    @Override
+    public void afterVariableChanged(ProcessVariableChangedEvent event) {
+
+    }
+}

--- a/src/main/java/org/slamon/StatsdProcessEventListener.java
+++ b/src/main/java/org/slamon/StatsdProcessEventListener.java
@@ -170,7 +170,6 @@ public class StatsdProcessEventListener implements ProcessEventListener {
             // send stats
             mClient.recordGaugeValue("process.running", mRunningProcesses.size());
             mClient.recordGaugeValue(createMetricName(event, "running"), mTotalProcesses.dec(event));
-            mClient.incrementCounter(metricName);
             mClient.recordExecutionTimeToNow(metricName, processStartTime);
         }
     }

--- a/src/test/java/org/slamon/StatsdProcessEventListenerTest.java
+++ b/src/test/java/org/slamon/StatsdProcessEventListenerTest.java
@@ -104,8 +104,6 @@ public class StatsdProcessEventListenerTest {
 
         verify(mMockClient, times(2)).incrementCounter("process.TestProcess2.started");
         verify(mMockClient, times(1)).incrementCounter("process.AnotherTestProcess1.started");
-        verify(mMockClient).incrementCounter("process.TestProcess2.completed");
-        verify(mMockClient).incrementCounter("process.TestProcess2.aborted");
     }
 
     @Test

--- a/src/test/java/org/slamon/StatsdProcessEventListenerTest.java
+++ b/src/test/java/org/slamon/StatsdProcessEventListenerTest.java
@@ -1,0 +1,115 @@
+package org.slamon;
+
+import com.timgroup.statsd.StatsDClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.kie.api.event.process.ProcessCompletedEvent;
+import org.kie.api.event.process.ProcessEvent;
+import org.kie.api.event.process.ProcessStartedEvent;
+import org.kie.api.runtime.process.ProcessInstance;
+
+
+import static org.mockito.Mockito.*;
+
+
+public class StatsdProcessEventListenerTest {
+
+    @Mock
+    private StatsDClient mMockClient;
+
+    @Before
+    public void initMocks() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    ProcessInstance mockProcess(final String name) {
+        final ProcessInstance mockInstance = mock(ProcessInstance.class);
+        when(mockInstance.getId()).thenReturn((long) mockInstance.hashCode());
+        when(mockInstance.getProcessId()).thenReturn(name);
+        when(mockInstance.getProcessName()).thenReturn(name);
+        return mockInstance;
+    }
+
+    static <T extends ProcessEvent> T mockProcessEvent(Class<T> eventClass, ProcessInstance process) {
+        T mockEvent = mock(eventClass);
+        when(mockEvent.getProcessInstance()).thenReturn(process);
+        return mockEvent;
+    }
+
+    @Test
+    public void testRunningGauges() throws Exception {
+        StatsdProcessEventListener listener = new StatsdProcessEventListener(mMockClient);
+
+        ProcessInstance mockInstance1 = mockProcess("Test Process-2");
+        ProcessInstance mockInstance2 = mockProcess("Test Process-2");
+        ProcessInstance mockInstance3 = mockProcess("Another Test Process-1");
+
+        // start three processes
+        listener.afterProcessStarted(mockProcessEvent(ProcessStartedEvent.class, mockInstance1));
+        listener.afterProcessStarted(mockProcessEvent(ProcessStartedEvent.class, mockInstance2));
+        listener.afterProcessStarted(mockProcessEvent(ProcessStartedEvent.class, mockInstance3));
+
+        // complete two processes, one with completed status and one with aborted status
+        when(mockInstance2.getState()).thenReturn(ProcessInstance.STATE_ABORTED);
+        listener.afterProcessCompleted(mockProcessEvent(ProcessCompletedEvent.class, mockInstance2));
+        when(mockInstance1.getState()).thenReturn(ProcessInstance.STATE_COMPLETED);
+        listener.afterProcessCompleted(mockProcessEvent(ProcessCompletedEvent.class, mockInstance1));
+
+        // verify total running gauge
+        verify(mMockClient, times(2)).recordGaugeValue("process.running", 1);
+        verify(mMockClient, times(2)).recordGaugeValue("process.running", 2);
+        verify(mMockClient, times(1)).recordGaugeValue("process.running", 3);
+
+        // verify per process definition gauges
+        verify(mMockClient, times(2)).recordGaugeValue("process.TestProcess2.running", 1);
+        verify(mMockClient).recordGaugeValue("process.TestProcess2.running", 2);
+        verify(mMockClient).recordGaugeValue("process.TestProcess2.running", 0);
+        verify(mMockClient).recordGaugeValue("process.AnotherTestProcess1.running", 1);
+    }
+
+    @Test
+    public void testRunningTimeEmitted() throws Exception {
+        StatsdProcessEventListener listener = new StatsdProcessEventListener(mMockClient);
+
+        ProcessInstance mockInstance1 = mockProcess("Test Process-2");
+        listener.afterProcessStarted(mockProcessEvent(ProcessStartedEvent.class, mockInstance1));
+
+        when(mockInstance1.getState()).thenReturn(ProcessInstance.STATE_COMPLETED);
+        listener.afterProcessCompleted(mockProcessEvent(ProcessCompletedEvent.class, mockInstance1));
+
+        verify(mMockClient).recordExecutionTimeToNow(eq("process.TestProcess2.completed"), anyLong());
+    }
+
+    @Test
+    public void testCounters() throws Exception {
+        StatsdProcessEventListener listener = new StatsdProcessEventListener(mMockClient);
+
+        ProcessInstance mockInstance1 = mockProcess("Test Process-2");
+        ProcessInstance mockInstance2 = mockProcess("Test Process-2");
+        ProcessInstance mockInstance3 = mockProcess("Another Test Process-1");
+
+        // start three processes
+        listener.afterProcessStarted(mockProcessEvent(ProcessStartedEvent.class, mockInstance1));
+        listener.afterProcessStarted(mockProcessEvent(ProcessStartedEvent.class, mockInstance2));
+        listener.afterProcessStarted(mockProcessEvent(ProcessStartedEvent.class, mockInstance3));
+
+        // complete two processes, one with completed status and one with aborted status
+        when(mockInstance2.getState()).thenReturn(ProcessInstance.STATE_ABORTED);
+        listener.afterProcessCompleted(mockProcessEvent(ProcessCompletedEvent.class, mockInstance2));
+        when(mockInstance1.getState()).thenReturn(ProcessInstance.STATE_COMPLETED);
+        listener.afterProcessCompleted(mockProcessEvent(ProcessCompletedEvent.class, mockInstance1));
+
+        verify(mMockClient, times(2)).incrementCounter("process.TestProcess2.started");
+        verify(mMockClient, times(1)).incrementCounter("process.AnotherTestProcess1.started");
+        verify(mMockClient).incrementCounter("process.TestProcess2.completed");
+        verify(mMockClient).incrementCounter("process.TestProcess2.aborted");
+    }
+
+    @Test
+    public void testAfterProcessCompleted() throws Exception {
+
+    }
+}


### PR DESCRIPTION
_Feature_: Added a jBPM ProcessEventListener implementation to send statistics to a statsd server:
- Process run/execution time
- Process started, completed and aborted counters
- Running process gauges

_Fix_: Revised behavior when a work item returns with an error to automatically abort the process.

_Refactoring_: Enabled Java 7 try-with-statement to clean up the code.
