### PR TITLE
Fix completing leftover processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ StatsdProcessEventListener will record
 Enable StatsD stats reporting by adding an entry in the project deployment descriptor with
 value = `new org.slamon.StatsdProcessEventListener()` and resolver type = mvel.
 
+**NOTE:** As *StatsdProcessEventListener* currently tracks processes using in memory store, it only works in single node
+setups and can not track persistent processes across restarts.
+
 #### Configuration
 
 StatsdProcessEventListener may be configured in two ways: constructor parameters and system properties.

--- a/src/main/java/org/slamon/StatsdProcessEventListener.java
+++ b/src/main/java/org/slamon/StatsdProcessEventListener.java
@@ -147,7 +147,12 @@ public class StatsdProcessEventListener implements ProcessEventListener {
     public void afterProcessCompleted(ProcessCompletedEvent event) {
         synchronized (mClient) {
             // calculate process duration from stored value
-            long processStartTime = mRunningProcesses.remove(event.getProcessInstance().getId());
+            Long processStartTime = mRunningProcesses.remove(event.getProcessInstance().getId());
+            if (processStartTime == null) {
+                log.log(Level.WARNING, "Unknown process {0} completed with status {1}", new Object[]{
+                        event.getProcessInstance().getId(), event.getProcessInstance().getState()});
+                return;
+            }
 
             // Generate metric name for recording stats
             String metricName;

--- a/src/main/java/org/slamon/StatsdProcessEventListener.java
+++ b/src/main/java/org/slamon/StatsdProcessEventListener.java
@@ -100,19 +100,12 @@ public class StatsdProcessEventListener implements ProcessEventListener {
         return name.replaceAll("[^a-zA-Z0-9]", "");
     }
 
-    static private String createProcessName(ProcessInstance process, KieRuntime runtime) {
-        long parentId = process.getParentProcessInstanceId();
-        if (parentId != 0) {
-            return createProcessName(runtime.getProcessInstance(parentId), runtime) + '.' + filterName(process.getProcessName());
-        }
-        return filterName(process.getProcessName());
-    }
-
     private String createMetricName(ProcessEvent event, String suffix) {
+
         synchronized (mClient) {
             mBuilder.setLength(0);
             mBuilder.append("process.")
-                    .append(createProcessName(event.getProcessInstance(), event.getKieRuntime()))
+                    .append(filterName(event.getProcessInstance().getProcessName()))
                     .append('.')
                     .append(suffix);
             return mBuilder.toString();


### PR DESCRIPTION
jBPM currently refuses to abort/delete old processes after restart because of unhandled exception:

```
07:05:50,927 WARN  [org.drools.persistence.SingleSessionCommandService] (default task-64) Could not commit session: java.lang.NullPointerException
        at org.slamon.StatsdProcessEventListener.afterProcessCompleted(StatsdProcessEventListener.java:150) [slamon-jbpm.jar:]
        at org.drools.core.event.ProcessEventSupport.fireAfterProcessCompleted(ProcessEventSupport.java:76) [drools-core-6.2.0.Final.jar:6.2.0.Final]
        at org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl.setState(WorkflowProcessInstanceImpl.java:315) [jbpm-flow-6.2.0.Final.jar:6.2.0.Final]
        at org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl.setState(WorkflowProcessInstanceImpl.java:334) [jbpm-flow-6.2.0.Final.jar:6.2.0.Final]
        at org.jbpm.process.instance.ProcessRuntimeImpl.abortProcessInstance(ProcessRuntimeImpl.java:484) [jbpm-flow-6.2.0.Final.jar:6.2.0.Final]
        at org.drools.core.impl.StatefulKnowledgeSessionImpl.abortProcessInstance(StatefulKnowledgeSessionImpl.java:527) [drools-core-6.2.0.Final.jar:6.2.0.Final]
...
```

This is because StatsD publisher/event listener tracks processes using in memory store. After jBPM restart this will be empty, but jBPM with persistency enabled will rediscover processes from previous launches in the persistency database.

This PR allows StatsdProcessEventListener to process events for tasks not present in the in-memory map.

Furthermore this changes how the statsd metrics names are generated: only leaf level process name is included in the metric name for simplicity and better predictability.
